### PR TITLE
OPENEUROPA-3048: Update rdf_skos to use sparql storage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ phpunit.xml
 runner.yml
 vendor
 yarn.lock
+/.gitattributes

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This depends on the following software:
 
 ## Installation
 
-This module indirectly depends on the [drupal/rdf_entity](https://www.drupal.org/project/rdf_entity) module, which requires a more updated version of `easyrdf/easyrdf` package.\
+This module indirectly depends on the [drupal/sparql_entity_storage](https://www.drupal.org/project/sparql_entity_storage) module, which requires a more updated version of `easyrdf/easyrdf` package.\
 First the correct version of this package should be installed:
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=7.2",
         "drupal/core": "^8.7",
         "easyrdf/easyrdf": "1.0.0 as 0.9.1",
-        "openeuropa/rdf_skos": "dev-OPENEUROPA-3048"
+        "openeuropa/rdf_skos": "~1.0"
     },
     "require-dev": {
         "composer/installers": "~1.5",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "drush/drush": "~9.0@stable",
         "guzzlehttp/guzzle": "~6.3",
         "openeuropa/code-review": "~1.1",
-        "openeuropa/drupal-core-require-dev": "^8.7",
+        "openeuropa/drupal-core-require-dev": "dev-EWPP-109",
         "openeuropa/task-runner": "~1.0.0-beta5",
         "phpunit/phpunit": "~6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=7.2",
         "drupal/core": "^8.7",
-        "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.2",
+        "easyrdf/easyrdf": "1.0.0 as 0.9.2",
         "openeuropa/rdf_skos": "dev-OPENEUROPA-3048"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=7.2",
         "drupal/core": "^8.7",
-        "easyrdf/easyrdf": "1.0.0 as 0.9.2",
+        "easyrdf/easyrdf": "1.0.0 as 0.9.1",
         "openeuropa/rdf_skos": "dev-OPENEUROPA-3048"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "drush/drush": "~9.0@stable",
         "guzzlehttp/guzzle": "~6.3",
         "openeuropa/code-review": "~1.1",
-        "openeuropa/drupal-core-require-dev": "dev-EWPP-109",
+        "openeuropa/drupal-core-require-dev": "^8.9.13",
         "openeuropa/task-runner": "~1.0.0-beta5",
         "phpunit/phpunit": "~6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=7.2",
         "drupal/core": "^8.7",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.2",
-        "openeuropa/rdf_skos": "~0.11"
+        "openeuropa/rdf_skos": "dev-OPENEUROPA-3048"
     },
     "require-dev": {
         "composer/installers": "~1.5",

--- a/modules/oe_corporate_countries_address/tests/src/Kernel/CountryRepositoryOverrideTest.php
+++ b/modules/oe_corporate_countries_address/tests/src/Kernel/CountryRepositoryOverrideTest.php
@@ -6,12 +6,12 @@ namespace Drupal\Tests\oe_corporate_countries_address\Kernel;
 
 use CommerceGuys\Addressing\Country\CountryRepositoryInterface;
 use Drupal\oe_corporate_countries_address\Repository\CountryRepository;
-use Drupal\Tests\rdf_entity\Kernel\RdfKernelTestBase;
+use Drupal\Tests\sparql_entity_storage\Kernel\SparqlKernelTestBase;
 
 /**
  * Tests the country repository service override.
  */
-class CountryRepositoryOverrideTest extends RdfKernelTestBase {
+class CountryRepositoryOverrideTest extends SparqlKernelTestBase {
 
   /**
    * {@inheritdoc}

--- a/modules/oe_corporate_countries_address/tests/src/Kernel/CountryRepositoryTest.php
+++ b/modules/oe_corporate_countries_address/tests/src/Kernel/CountryRepositoryTest.php
@@ -28,7 +28,7 @@ class CountryRepositoryTest extends CorporateCountriesRdfKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installEntitySchema('configurable_language');

--- a/modules/oe_corporate_countries_address/tests/src/Kernel/FieldConstraintValidationTest.php
+++ b/modules/oe_corporate_countries_address/tests/src/Kernel/FieldConstraintValidationTest.php
@@ -27,7 +27,7 @@ class FieldConstraintValidationTest extends CorporateCountriesRdfKernelTestBase 
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installEntitySchema('entity_test');

--- a/oe_corporate_countries.services.yml
+++ b/oe_corporate_countries.services.yml
@@ -1,4 +1,4 @@
 services:
   oe_corporate_countries.corporate_country_repository:
     class: Drupal\oe_corporate_countries\CorporateCountryRepository
-    arguments: ['@rdf_skos.sparql.graph_handler', '@sparql_endpoint']
+    arguments: ['@rdf_skos.sparql.graph_handler', '@sparql.endpoint']

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,7 +6,7 @@
     <env name="SIMPLETEST_IGNORE_DIRECTORIES" value="${drupal.root}"/>
     <env name="SIMPLETEST_BASE_URL" value="${drupal.base_url}"/>
     <env name="SIMPLETEST_DB" value="mysql://${drupal.database.user}:${drupal.database.password}@${drupal.database.host}:${drupal.database.port}/${drupal.database.name}"/>
-    <env name="SIMPLETEST_SPARQL_DB" value="sparql://${drupal.sparql.host}:${drupal.sparql.port}/"/>
+    <env name="SIMPLETEST_SPARQL_DB" value="sparql://${drupal.sparql.host}:${drupal.sparql.port}/?module=sparql_entity_storage"/>
   </php>
   <testsuites>
     <testsuite>

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -40,7 +40,7 @@ drupal:
           prefix: ""
           host: ${drupal.sparql.host}
           port: ${drupal.sparql.port}
-          namespace: 'Drupal\Driver\Database\sparql'
+          namespace: 'Drupal\sparql_entity_storage\Driver\Database\sparql'
           driver: 'sparql'
 
 commands:

--- a/src/CorporateCountryRepository.php
+++ b/src/CorporateCountryRepository.php
@@ -5,7 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\oe_corporate_countries;
 
 use Drupal\Component\Serialization\Json;
-use Drupal\sparql_entity_storage\Database\Driver\sparql\ConnectionInterface;
+use Drupal\sparql_entity_storage\Driver\Database\sparql\ConnectionInterface;
 use Drupal\sparql_entity_storage\Entity\Query\Sparql\SparqlArg;
 use Drupal\sparql_entity_storage\SparqlEntityStorageGraphHandlerInterface;
 
@@ -24,7 +24,7 @@ class CorporateCountryRepository implements CorporateCountryRepositoryInterface 
   /**
    * The SPARQL database connection.
    *
-   * @var \Drupal\sparql_entity_storage\Database\Driver\sparql\ConnectionInterface
+   * @var \Drupal\sparql_entity_storage\Driver\Database\sparql\ConnectionInterface
    */
   protected $sparql;
 
@@ -33,7 +33,7 @@ class CorporateCountryRepository implements CorporateCountryRepositoryInterface 
    *
    * @param \Drupal\sparql_entity_storage\SparqlEntityStorageGraphHandlerInterface $graphHandler
    *   The graph handler service.
-   * @param \Drupal\sparql_entity_storage\Database\Driver\sparql\ConnectionInterface $sparql
+   * @param \Drupal\sparql_entity_storage\Driver\Database\sparql\ConnectionInterface $sparql
    *   The SPARQL database connection.
    */
   public function __construct(SparqlEntityStorageGraphHandlerInterface $graphHandler, ConnectionInterface $sparql) {

--- a/src/CorporateCountryRepository.php
+++ b/src/CorporateCountryRepository.php
@@ -5,9 +5,9 @@ declare(strict_types = 1);
 namespace Drupal\oe_corporate_countries;
 
 use Drupal\Component\Serialization\Json;
-use Drupal\rdf_entity\Database\Driver\sparql\ConnectionInterface;
-use Drupal\rdf_entity\Entity\Query\Sparql\SparqlArg;
-use Drupal\rdf_entity\RdfGraphHandlerInterface;
+use Drupal\sparql_entity_storage\Database\Driver\sparql\ConnectionInterface;
+use Drupal\sparql_entity_storage\Entity\Query\Sparql\SparqlArg;
+use Drupal\sparql_entity_storage\SparqlEntityStorageGraphHandlerInterface;
 
 /**
  * A corporate country repository implementation.
@@ -17,26 +17,26 @@ class CorporateCountryRepository implements CorporateCountryRepositoryInterface 
   /**
    * The graph handler.
    *
-   * @var \Drupal\rdf_entity\RdfGraphHandlerInterface
+   * @var \Drupal\sparql_entity_storage\SparqlEntityStorageGraphHandlerInterface
    */
   protected $graphHandler;
 
   /**
    * The SPARQL database connection.
    *
-   * @var \Drupal\rdf_entity\Database\Driver\sparql\ConnectionInterface
+   * @var \Drupal\sparql_entity_storage\Database\Driver\sparql\ConnectionInterface
    */
   protected $sparql;
 
   /**
    * Instantiates a new CorporateCountryRepository object.
    *
-   * @param \Drupal\rdf_entity\RdfGraphHandlerInterface $graphHandler
+   * @param \Drupal\sparql_entity_storage\SparqlEntityStorageGraphHandlerInterface $graphHandler
    *   The graph handler service.
-   * @param \Drupal\rdf_entity\Database\Driver\sparql\ConnectionInterface $sparql
+   * @param \Drupal\sparql_entity_storage\Database\Driver\sparql\ConnectionInterface $sparql
    *   The SPARQL database connection.
    */
-  public function __construct(RdfGraphHandlerInterface $graphHandler, ConnectionInterface $sparql) {
+  public function __construct(SparqlEntityStorageGraphHandlerInterface $graphHandler, ConnectionInterface $sparql) {
     $this->graphHandler = $graphHandler;
     $this->sparql = $sparql;
   }

--- a/src/Plugin/ConceptSubset/NonDeprecatedCountries.php
+++ b/src/Plugin/ConceptSubset/NonDeprecatedCountries.php
@@ -7,9 +7,9 @@ namespace Drupal\oe_corporate_countries\Plugin\ConceptSubset;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\rdf_entity\RdfFieldHandlerInterface;
 use Drupal\rdf_skos\ConceptSubsetPluginBase;
 use Drupal\rdf_skos\Plugin\PredicateMapperInterface;
+use Drupal\sparql_entity_storage\SparqlEntityStorageFieldHandlerInterface;
 
 /**
  * Subset of the countries vocabulary with non-deprecated countries only.
@@ -44,7 +44,7 @@ class NonDeprecatedCountries extends ConceptSubsetPluginBase implements Predicat
     $mapping['deprecated'] = [
       'column' => 'value',
       'predicate' => ['http://publications.europa.eu/ontology/authority/deprecated'],
-      'format' => RdfFieldHandlerInterface::NON_TYPE,
+      'format' => SparqlEntityStorageFieldHandlerInterface::NON_TYPE,
     ];
 
     return $mapping;

--- a/tests/src/Kernel/CorporateCountriesRdfKernelTestBase.php
+++ b/tests/src/Kernel/CorporateCountriesRdfKernelTestBase.php
@@ -4,13 +4,13 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_corporate_countries\Kernel;
 
-use Drupal\Tests\rdf_entity\Kernel\RdfKernelTestBase;
+use Drupal\Tests\sparql_entity_storage\Kernel\SparqlKernelTestBase;
 use Drupal\Tests\rdf_skos\Traits\SkosImportTrait;
 
 /**
  * Abstract class for kernel tests with a test RDF country vocabulary.
  */
-abstract class CorporateCountriesRdfKernelTestBase extends RdfKernelTestBase {
+abstract class CorporateCountriesRdfKernelTestBase extends SparqlKernelTestBase {
 
   use SkosImportTrait;
 
@@ -25,7 +25,7 @@ abstract class CorporateCountriesRdfKernelTestBase extends RdfKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $base_url = $_ENV['SIMPLETEST_BASE_URL'];
@@ -36,7 +36,7 @@ abstract class CorporateCountriesRdfKernelTestBase extends RdfKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public function tearDown() {
+  public function tearDown(): void {
     $base_url = $_ENV['SIMPLETEST_BASE_URL'];
     $this->clear($base_url, $this->sparql, 'phpunit');
 

--- a/tests/src/Kernel/CorporateCountrySubsetTest.php
+++ b/tests/src/Kernel/CorporateCountrySubsetTest.php
@@ -16,6 +16,8 @@ class CorporateCountrySubsetTest extends CorporateCountriesRdfKernelTestBase {
    */
   public static $modules = [
     'oe_corporate_countries',
+    'entity_test',
+    'user',
   ];
 
   /**
@@ -23,6 +25,10 @@ class CorporateCountrySubsetTest extends CorporateCountriesRdfKernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
+
+    $this->installEntitySchema('entity_test');
+    $this->installEntitySchema('user');
+
     $this->enableGraph('country_test');
   }
 


### PR DESCRIPTION
## OPENEUROPA-3048
### Description

 Update rdf_skos to use sparql storage.

### Change log

- Added:
- Changed:  Update rdf_skos to use sparql storage.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

