### PR TITLE
OES-2019: Country field doesn't show elements in the view exposed filter.

### DIFF
--- a/modules/oe_corporate_countries_address/src/EventSubscriber/AvailableCountriesSubscriber.php
+++ b/modules/oe_corporate_countries_address/src/EventSubscriber/AvailableCountriesSubscriber.php
@@ -52,10 +52,12 @@ class AvailableCountriesSubscriber implements EventSubscriberInterface {
     // If no available countries are passed, default it to all available ones.
     if (empty($available_countries)) {
       $available_countries = array_column($this->corporateCountryRepository->getCountries(), 'alpha-2');
+      $available_countries = array_combine($available_countries, $available_countries);
     }
 
     // Extract the alpha-2 of all deprecated countries.
     $deprecated_countries = array_column($this->corporateCountryRepository->getDeprecatedCountries(), 'alpha-2');
+    $deprecated_countries = array_combine($deprecated_countries, $deprecated_countries);
 
     // Exclude all the deprecated countries from availability.
     $event->setAvailableCountries(array_diff($available_countries, $deprecated_countries));


### PR DESCRIPTION
## OES-2019

### Description

**The problem:**
An exposed views filter for the Country type field (from the address module) shows an empty dropdown list.

I reported the following problem in the ticket OES-2019 but it was not checked as I asked and not forwarded to the next level of support. Finally, I did an investigation and found the cause of the problem and created this PR to fix it.

**Steps to reproduce:**
- Add a Country type field (address_country) with the default settings to any content type
- Create a view with an exposed filter for the Country field
- On the front page, the Country filter has an empty list and doesn't show any country in the dropdown selector

The problem doesn't exist with clean D9 instance + Views + Address modules.

### Change log

- Fixed: The function `removeDeprecatedCountries()` in the "Available countries event subscriber" returns the country codes as values but the function `getAvailableCountries()` in `CountryAwareInOperatorBase` expects to retrieve the keys as the country codes:
```
$available_countries = $this->countryRepository->getList();
if (!empty($countries)) {
  $available_countries = array_intersect_key($available_countries, $countries);
}
```
Otherwise, the views exposed filter has always an empty list of countries because `array_intersect_key()` will return an empty array as the array `$available_countries` has country codes as keys and country names as values but `$countries` array has country codes as values and keys are incremental integers 0..n. 

### Commands

```sh
drush cr

```

