### PR TITLE
Populate array key in Eventsubscriber. Add functional tests.

### DIFF
--- a/modules/oe_corporate_countries_address/src/EventSubscriber/AvailableCountriesSubscriber.php
+++ b/modules/oe_corporate_countries_address/src/EventSubscriber/AvailableCountriesSubscriber.php
@@ -52,12 +52,16 @@ class AvailableCountriesSubscriber implements EventSubscriberInterface {
     // If no available countries are passed, default it to all available ones.
     if (empty($available_countries)) {
       $available_countries = array_column($this->corporateCountryRepository->getCountries(), 'alpha-2');
+      // Ensure that the same value is duplicated as key and value of the array.
+      $available_countries = array_combine($available_countries, $available_countries);
     }
 
     // Extract the alpha-2 of all deprecated countries.
     $deprecated_countries = array_column($this->corporateCountryRepository->getDeprecatedCountries(), 'alpha-2');
+    // Ensure that the same value is duplicated as key and value of the array.
+    $deprecated_countries = array_combine($deprecated_countries, $deprecated_countries);
 
-    // Exclude all the deprecated countries from availability.
+    // Exclude all the deprecated countries from the available countries.
     $event->setAvailableCountries(array_diff($available_countries, $deprecated_countries));
   }
 

--- a/modules/oe_corporate_countries_address/tests/src/Kernel/AvailableCountriesSubscriberTest.php
+++ b/modules/oe_corporate_countries_address/tests/src/Kernel/AvailableCountriesSubscriberTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\oe_corporate_countries_address\Kernel;
+
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\Tests\oe_corporate_countries\Kernel\CorporateCountriesRdfKernelTestBase;
+
+/**
+ * Tests the AvailableCountriesSubscriber class.
+ */
+class AvailableCountriesSubscriberTest extends CorporateCountriesRdfKernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'user',
+    'entity_test',
+    'address',
+    'oe_corporate_countries_address',
+  ];
+
+  /**
+   * Tests the deprecated countries are removed from the countries array.
+   */
+  public function testGetAvailableCountriesArray(): void {
+
+    $entityTypeName = 'entity_test';
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_country',
+      'entity_type' => 'entity_test',
+      'type' => 'address_country',
+    ])->save();
+
+    FieldConfig::create([
+      'label' => 'My field',
+      'field_name' => 'field_country',
+      'entity_type' => 'entity_test',
+      'bundle' => 'entity_test',
+    ])->save();
+
+    // Get the actual countries from field.
+    // This shouldn't have the deprecated countries.
+    $entity = EntityTest::create();
+    $actual_countries = $entity->get('field_country')
+      ->appendItem()
+      ->getAvailableCountries();
+
+    // These are the expected countries we want to check for.
+    $expected_countries = [
+      'XK' => 'XK',
+      'AX' => 'AX',
+      'BE' => 'BE',
+      'TF' => 'TF',
+      'IT' => 'IT',
+    ];
+
+    // Assert explicitly that the actual countries format is correctly formated.
+    foreach ($actual_countries as $key => $value) {
+      $this->assertArrayHasKey($key, $expected_countries, 'Key ' . ' has been found');
+    }
+
+    // Assert explicitly that the actual countries array is correctly keyed.
+    $expected_keys = array_keys($expected_countries);
+    $actual_keys = array_keys($actual_countries);
+    sort($expected_keys);
+    sort($actual_keys);
+    $this->assertEquals($expected_keys, $actual_keys, 'The actual countries array is correctly keyed');
+
+    // Assert explicitly actual countries against a deprecated country.
+    $this->assertArrayNotHasKey('AN', $actual_countries, 'The deprecated country "AN" is not present in actual_countries array');
+  }
+
+}

--- a/modules/oe_corporate_countries_address/tests/src/Kernel/AvailableCountriesSubscriberTest.php
+++ b/modules/oe_corporate_countries_address/tests/src/Kernel/AvailableCountriesSubscriberTest.php
@@ -28,24 +28,20 @@ class AvailableCountriesSubscriberTest extends CorporateCountriesRdfKernelTestBa
    * Tests the deprecated countries are removed from the countries array.
    */
   public function testGetAvailableCountriesArray(): void {
-
-    $entityTypeName = 'entity_test';
-
-    FieldStorageConfig::create([
+    $field_storage = FieldStorageConfig::create([
       'field_name' => 'field_country',
       'entity_type' => 'entity_test',
       'type' => 'address_country',
-    ])->save();
+    ]);
+    $field_storage->save();
 
     FieldConfig::create([
-      'label' => 'My field',
-      'field_name' => 'field_country',
-      'entity_type' => 'entity_test',
+      'field_storage' => $field_storage,
       'bundle' => 'entity_test',
+      'label' => 'My field',
     ])->save();
 
     // Get the actual countries from field.
-    // This shouldn't have the deprecated countries.
     $entity = EntityTest::create();
     $actual_countries = $entity->get('field_country')
       ->appendItem()
@@ -60,20 +56,9 @@ class AvailableCountriesSubscriberTest extends CorporateCountriesRdfKernelTestBa
       'IT' => 'IT',
     ];
 
-    // Assert explicitly that the actual countries format is correctly formated.
-    foreach ($actual_countries as $key => $value) {
-      $this->assertArrayHasKey($key, $expected_countries, 'Key ' . ' has been found');
-    }
-
-    // Assert explicitly that the actual countries array is correctly keyed.
-    $expected_keys = array_keys($expected_countries);
-    $actual_keys = array_keys($actual_countries);
-    sort($expected_keys);
-    sort($actual_keys);
-    $this->assertEquals($expected_keys, $actual_keys, 'The actual countries array is correctly keyed');
-
-    // Assert explicitly actual countries against a deprecated country.
-    $this->assertArrayNotHasKey('AN', $actual_countries, 'The deprecated country "AN" is not present in actual_countries array');
+    // Assert that the actual countries array is correctly keyed.
+    $this->assertEquals($expected_countries, $actual_countries);
+    // Assert that the actual countries do not contain deprecated countries.
+    $this->assertNotContains('AN', $actual_countries);
   }
-
 }


### PR DESCRIPTION
## OES-2019

### Description

An exposed views filter for the Country type field (from the address module) shows an empty dropdown list.

It was reported the following problem in the ticket OES-2019 but it was not checked as it was asked and not forwarded to the next level of support. Finally, an investigation was done and the problem solved under PR 30.

In this PR we add functional testing.

### Steps to reproduce:

Add a Country type field (address_country) with the default settings to any content type
Create a view with an exposed filter for the Country field
On the front page, the Country filter has an empty list and doesn't show any country in the dropdown selector
The problem doesn't exist with clean D9 instance + Views + Address modules.

### Change log

- Added: 

14/feb/2023 

https://github.com/openeuropa/oe_corporate_countries/pull/30/commits/542cbba36b109de87c082c7273610ae6103eefe8#diff-2b65b02f601fec6e9c289b306e4b9f365bbc23c0a181be7e62727b01b0ef79c4

- Changed: 19/mar/2024

[This PR](https://github.com/openeuropa/oe_corporate_countries/compare/2.x...pierregermain:oe_corporate_countries:OES-2019-Exposed-Filter?diff=unified&w=)

### Commands

To do the functional tests:

```
docker-compose exec web ./vendor/bin/phpunit ./build/modules/custom/oe_corporate_countries/tests/src/Functional/CorporateCountriesFilterTest.php 
```

